### PR TITLE
Open external links from the privacy view in the browser

### DIFF
--- a/app/src/main/java/com/freetime/geoweather/PrivacyWebView.kt
+++ b/app/src/main/java/com/freetime/geoweather/PrivacyWebView.kt
@@ -1,6 +1,8 @@
 package com.freetime.geoweather
 
 import android.content.Context
+import android.content.Intent
+import android.content.ActivityNotFoundException
 import android.util.AttributeSet
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
@@ -43,6 +45,20 @@ class PrivacyWebView(context: Context, attrs: AttributeSet? = null) :
     }
 
     private class PrivacyClient : WebViewClient() {
+        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+            val url = request?.url ?: return false
+            if (url.scheme == "http" || url.scheme == "https") {
+                val context = view?.context ?: return false
+                try {
+                    context.startActivity(Intent(Intent.ACTION_VIEW, url))
+                } catch (e: ActivityNotFoundException) {
+                    // no app available to open the link
+                }
+                return true
+            }
+            return false
+        }
+
 
         private val blockedHosts = listOf(
             "google-analytics.com",


### PR DESCRIPTION
This adds a `shouldOverrideUrlLoading` override to the privacy view so that http and https links open in the system browser instead of loading inside the view.

The privacy view has no toolbar or back control, so a link tapped today loads in place and leaves the user with no clear way back. With this change normal web links go to the browser, other schemes are left to the default behavior, and a missing handler is caught so it cannot crash the view.

Closes #94.